### PR TITLE
Added the option to add specific query params to geocoding options

### DIFF
--- a/__tests__/geocoding.test.ts
+++ b/__tests__/geocoding.test.ts
@@ -26,6 +26,13 @@ describe('NodeGeolocation should return geocoding data correctly using Nominatim
         expect(data.address.city).toBe("Roma");
         expect(data.address.country).toBe("Italia");
     });
+
+    it('Should work with additional query parameters', async () => {
+        const data = await geo.getGeocoding('Rome, Italy', { format: 'json' });
+        expect(data).toBeDefined();
+        expect(data.address.city).toBe("Roma");
+        expect(data.address.country).toBe("Italia");
+    });
 });
 
 describe('NodeGeolocation should return geocoding data correctly using Here', () => {
@@ -46,7 +53,14 @@ describe('NodeGeolocation should return geocoding data correctly using Here', ()
     it('Should return reverse geocoding data', async () => {
         const data = await geo.getReverseGeocoding({ lat: 41.8933203, lon: 12.4829321 });
         expect(data).toBeDefined();
-        expect(data.address.city).toBe("Rome");
-        expect(data.address.countryName).toBe("Italy");
+        expect(data.address.city).toBe("Roma");
+        expect(data.address.countryName).toBe("Italia");
+    });
+
+    it('Should work with additional query parameters', async () => {
+        const data = await geo.getGeocoding('Rome, Italy', { lang: 'it' });
+        expect(data).toBeDefined();
+        expect(data.address.city).toBe("Roma");
+        expect(data.address.country).toBe("Italia");
     });
 });

--- a/lib/cjs/index.cjs
+++ b/lib/cjs/index.cjs
@@ -136,12 +136,12 @@ class NodeGeolocation {
      * @param address Address string to geocode
      * @returns Geocoding data
      */
-    getGeocoding(address) {
+    getGeocoding(address, queryParameters) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!this.geocodingOptions)
                 throw new Error('You must set geocodingOptions object before using this method');
             if (this.geocodingOptions.service === 'Nominatim') {
-                const data = yield (0, geocodeNominatim_js_1.geocodeNominatim)(address, this._id);
+                const data = yield (0, geocodeNominatim_js_1.geocodeNominatim)(address, this._id, queryParameters);
                 return {
                     id: data.place_id,
                     address: {
@@ -166,7 +166,7 @@ class NodeGeolocation {
                 };
             }
             else if (this.geocodingOptions.service === 'Here') {
-                const data = yield (0, geocodeHere_js_1.geocodeHere)(address, this.geocodingOptions.key, this._id);
+                const data = yield (0, geocodeHere_js_1.geocodeHere)(address, this.geocodingOptions.key, this._id, queryParameters);
                 return {
                     id: data.id,
                     address: {
@@ -201,7 +201,7 @@ class NodeGeolocation {
      * @param pos Position to reverse geocode
      * @returns Reverse geocoding data
      */
-    getReverseGeocoding(pos) {
+    getReverseGeocoding(pos, queryParameters) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!this.geocodingOptions)
                 throw new Error('You must set geocodingOptions object before using this method');
@@ -223,10 +223,10 @@ class NodeGeolocation {
                 throw new Error('Invalid position');
             }
             if (this.geocodingOptions.service === 'Nominatim') {
-                return yield (0, geocodeNominatim_js_1.reverseGeocodeNominatim)(lat, lon, this._id);
+                return yield (0, geocodeNominatim_js_1.reverseGeocodeNominatim)(lat, lon, this._id, queryParameters);
             }
             else if (this.geocodingOptions.service === 'Here') {
-                return yield (0, geocodeHere_js_1.reverseGeocodeHere)(lat, lon, this.geocodingOptions.key, this._id);
+                return yield (0, geocodeHere_js_1.reverseGeocodeHere)(lat, lon, this.geocodingOptions.key, this._id, queryParameters);
             }
             else {
                 throw new Error('Invalid service');

--- a/lib/cjs/index.d.cts
+++ b/lib/cjs/index.d.cts
@@ -42,14 +42,14 @@ declare class NodeGeolocation {
      * @param address Address string to geocode
      * @returns Geocoding data
      */
-    getGeocoding(address: string): Promise<GeocodingData>;
+    getGeocoding(address: string, queryParameters?: Record<string, string>): Promise<GeocodingData>;
     /**
      * Get reverse geocoding data from a position
      * @Important **You must set geocodingOptions object before using this method**
      * @param pos Position to reverse geocode
      * @returns Reverse geocoding data
      */
-    getReverseGeocoding(pos: Position): Promise<ReverseGeocodingData>;
+    getReverseGeocoding(pos: Position, queryParameters?: Record<string, string>): Promise<ReverseGeocodingData>;
     /**
      * Built-in unit converter
      * @param value Value to convert

--- a/lib/cjs/utils/geocodeHere.cjs
+++ b/lib/cjs/utils/geocodeHere.cjs
@@ -21,10 +21,15 @@ const httpsGet_js_1 = __importDefault(require("./httpsGet.cjs"));
  * @param appID Application ID
  * @returns Geocoded address
  */
-const geocodeHere = (address, apiKey, appID) => __awaiter(void 0, void 0, void 0, function* () {
+const geocodeHere = (address, apiKey, appID, queryParameters) => __awaiter(void 0, void 0, void 0, function* () {
     const encodedAddress = encodeURIComponent(address);
-    const url = `https://geocode.search.hereapi.com/v1/geocode?q=${encodedAddress}&apiKey=${apiKey}`;
-    const res = JSON.parse(yield (0, httpsGet_js_1.default)(url, appID));
+    const url = new URL(`https://geocode.search.hereapi.com/v1/geocode?q=${encodedAddress}&apiKey=${apiKey}`);
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            url.searchParams.append(key, queryParameters[key]);
+        }
+    }
+    const res = JSON.parse(yield (0, httpsGet_js_1.default)(url.toString(), appID));
     if (res.items.length === 0) {
         throw new Error('No results found');
     }
@@ -39,9 +44,14 @@ exports.geocodeHere = geocodeHere;
  * @param appID Application ID
  * @returns Reverse geocoded address
  */
-const reverseGeocodeHere = (lat, lon, apiKey, appID) => __awaiter(void 0, void 0, void 0, function* () {
-    const url = `https://revgeocode.search.hereapi.com/v1/revgeocode?at=${lat}%2C${lon}&apiKey=${apiKey}&lang=en-US`;
-    const res = JSON.parse(yield (0, httpsGet_js_1.default)(url, appID));
+const reverseGeocodeHere = (lat, lon, apiKey, appID, queryParameters) => __awaiter(void 0, void 0, void 0, function* () {
+    const url = new URL(`https://revgeocode.search.hereapi.com/v1/revgeocode?at=${lat}%2C${lon}&apiKey=${apiKey}`);
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            url.searchParams.append(key, queryParameters[key]);
+        }
+    }
+    const res = JSON.parse(yield (0, httpsGet_js_1.default)(url.toString(), appID));
     if (res.items.length === 0) {
         throw new Error('No results found');
     }

--- a/lib/cjs/utils/geocodeHere.d.cts
+++ b/lib/cjs/utils/geocodeHere.d.cts
@@ -5,7 +5,7 @@
  * @param appID Application ID
  * @returns Geocoded address
  */
-export declare const geocodeHere: (address: string, apiKey: string, appID: string) => Promise<any>;
+export declare const geocodeHere: (address: string, apiKey: string, appID: string, queryParameters?: Record<string, string>) => Promise<any>;
 /**
  * Reverse geocode address using Here API
  * @param lat Latitude
@@ -14,4 +14,4 @@ export declare const geocodeHere: (address: string, apiKey: string, appID: strin
  * @param appID Application ID
  * @returns Reverse geocoded address
  */
-export declare const reverseGeocodeHere: (lat: number, lon: number, apiKey: string, appID: string) => Promise<any>;
+export declare const reverseGeocodeHere: (lat: number, lon: number, apiKey: string, appID: string, queryParameters?: Record<string, string>) => Promise<any>;

--- a/lib/cjs/utils/geocodeNominatim.cjs
+++ b/lib/cjs/utils/geocodeNominatim.cjs
@@ -20,11 +20,16 @@ const httpsGet_js_1 = __importDefault(require("./httpsGet.cjs"));
  * @param appID Application ID
  * @returns Geocoded address
  */
-const geocodeNominatim = (address, appID) => __awaiter(void 0, void 0, void 0, function* () {
+const geocodeNominatim = (address, appID, queryParameters) => __awaiter(void 0, void 0, void 0, function* () {
     const encodedAddress = encodeURIComponent(address);
-    const apiUrl = `https://nominatim.openstreetmap.org/search?q=${encodedAddress}&format=json&addressdetails=1&limit=1`;
+    const apiUrl = new URL(`https://nominatim.openstreetmap.org/search?q=${encodedAddress}&format=json&addressdetails=1&limit=1`);
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            apiUrl.searchParams.append(key, queryParameters[key]);
+        }
+    }
     try {
-        const res = yield (0, httpsGet_js_1.default)(apiUrl, appID);
+        const res = yield (0, httpsGet_js_1.default)(apiUrl.toString(), appID);
         if (res.startsWith('<html>')) {
             throw new Error(res);
         }
@@ -55,12 +60,17 @@ exports.geocodeNominatim = geocodeNominatim;
  * @param appID Application ID
  * @returns Reverse geocoded address
  */
-const reverseGeocodeNominatim = (lat, lon, appID) => __awaiter(void 0, void 0, void 0, function* () {
+const reverseGeocodeNominatim = (lat, lon, appID, queryParameters) => __awaiter(void 0, void 0, void 0, function* () {
     const encodedLat = encodeURIComponent(lat);
     const encodedLon = encodeURIComponent(lon);
-    const apiUrl = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${encodedLat}&lon=${encodedLon}`;
+    const apiUrl = new URL(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${encodedLat}&lon=${encodedLon}`);
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            apiUrl.searchParams.append(key, queryParameters[key]);
+        }
+    }
     try {
-        const res = yield (0, httpsGet_js_1.default)(apiUrl, appID);
+        const res = yield (0, httpsGet_js_1.default)(apiUrl.toString(), appID);
         if (res.startsWith('<html>')) {
             throw new Error(res);
         }

--- a/lib/cjs/utils/geocodeNominatim.d.cts
+++ b/lib/cjs/utils/geocodeNominatim.d.cts
@@ -4,7 +4,7 @@
  * @param appID Application ID
  * @returns Geocoded address
  */
-export declare const geocodeNominatim: (address: string, appID: string) => Promise<any>;
+export declare const geocodeNominatim: (address: string, appID: string, queryParameters?: Record<string, string>) => Promise<any>;
 /**
  * Reverse geocode address using Nominatim
  * @param lat Latitude
@@ -12,4 +12,4 @@ export declare const geocodeNominatim: (address: string, appID: string) => Promi
  * @param appID Application ID
  * @returns Reverse geocoded address
  */
-export declare const reverseGeocodeNominatim: (lat: number | string, lon: number | string, appID: string) => Promise<any>;
+export declare const reverseGeocodeNominatim: (lat: number | string, lon: number | string, appID: string, queryParameters?: Record<string, string>) => Promise<any>;

--- a/lib/module/index.d.ts
+++ b/lib/module/index.d.ts
@@ -42,14 +42,14 @@ declare class NodeGeolocation {
      * @param address Address string to geocode
      * @returns Geocoding data
      */
-    getGeocoding(address: string): Promise<GeocodingData>;
+    getGeocoding(address: string, queryParameters?: Record<string, string>): Promise<GeocodingData>;
     /**
      * Get reverse geocoding data from a position
      * @Important **You must set geocodingOptions object before using this method**
      * @param pos Position to reverse geocode
      * @returns Reverse geocoding data
      */
-    getReverseGeocoding(pos: Position): Promise<ReverseGeocodingData>;
+    getReverseGeocoding(pos: Position, queryParameters?: Record<string, string>): Promise<ReverseGeocodingData>;
     /**
      * Built-in unit converter
      * @param value Value to convert

--- a/lib/module/index.js
+++ b/lib/module/index.js
@@ -116,12 +116,12 @@ class NodeGeolocation {
      * @param address Address string to geocode
      * @returns Geocoding data
      */
-    getGeocoding(address) {
+    getGeocoding(address, queryParameters) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!this.geocodingOptions)
                 throw new Error('You must set geocodingOptions object before using this method');
             if (this.geocodingOptions.service === 'Nominatim') {
-                const data = yield geocodeNominatim(address, this._id);
+                const data = yield geocodeNominatim(address, this._id, queryParameters);
                 return {
                     id: data.place_id,
                     address: {
@@ -146,7 +146,7 @@ class NodeGeolocation {
                 };
             }
             else if (this.geocodingOptions.service === 'Here') {
-                const data = yield geocodeHere(address, this.geocodingOptions.key, this._id);
+                const data = yield geocodeHere(address, this.geocodingOptions.key, this._id, queryParameters);
                 return {
                     id: data.id,
                     address: {
@@ -181,7 +181,7 @@ class NodeGeolocation {
      * @param pos Position to reverse geocode
      * @returns Reverse geocoding data
      */
-    getReverseGeocoding(pos) {
+    getReverseGeocoding(pos, queryParameters) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!this.geocodingOptions)
                 throw new Error('You must set geocodingOptions object before using this method');
@@ -203,10 +203,10 @@ class NodeGeolocation {
                 throw new Error('Invalid position');
             }
             if (this.geocodingOptions.service === 'Nominatim') {
-                return yield reverseGeocodeNominatim(lat, lon, this._id);
+                return yield reverseGeocodeNominatim(lat, lon, this._id, queryParameters);
             }
             else if (this.geocodingOptions.service === 'Here') {
-                return yield reverseGeocodeHere(lat, lon, this.geocodingOptions.key, this._id);
+                return yield reverseGeocodeHere(lat, lon, this.geocodingOptions.key, this._id, queryParameters);
             }
             else {
                 throw new Error('Invalid service');

--- a/lib/module/utils/geocodeHere.d.ts
+++ b/lib/module/utils/geocodeHere.d.ts
@@ -5,7 +5,7 @@
  * @param appID Application ID
  * @returns Geocoded address
  */
-export declare const geocodeHere: (address: string, apiKey: string, appID: string) => Promise<any>;
+export declare const geocodeHere: (address: string, apiKey: string, appID: string, queryParameters?: Record<string, string>) => Promise<any>;
 /**
  * Reverse geocode address using Here API
  * @param lat Latitude
@@ -14,4 +14,4 @@ export declare const geocodeHere: (address: string, apiKey: string, appID: strin
  * @param appID Application ID
  * @returns Reverse geocoded address
  */
-export declare const reverseGeocodeHere: (lat: number, lon: number, apiKey: string, appID: string) => Promise<any>;
+export declare const reverseGeocodeHere: (lat: number, lon: number, apiKey: string, appID: string, queryParameters?: Record<string, string>) => Promise<any>;

--- a/lib/module/utils/geocodeHere.js
+++ b/lib/module/utils/geocodeHere.js
@@ -15,10 +15,15 @@ import httpsGet from "./httpsGet.js";
  * @param appID Application ID
  * @returns Geocoded address
  */
-export const geocodeHere = (address, apiKey, appID) => __awaiter(void 0, void 0, void 0, function* () {
+export const geocodeHere = (address, apiKey, appID, queryParameters) => __awaiter(void 0, void 0, void 0, function* () {
     const encodedAddress = encodeURIComponent(address);
-    const url = `https://geocode.search.hereapi.com/v1/geocode?q=${encodedAddress}&apiKey=${apiKey}`;
-    const res = JSON.parse(yield httpsGet(url, appID));
+    const url = new URL(`https://geocode.search.hereapi.com/v1/geocode?q=${encodedAddress}&apiKey=${apiKey}`);
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            url.searchParams.append(key, queryParameters[key]);
+        }
+    }
+    const res = JSON.parse(yield httpsGet(url.toString(), appID));
     if (res.items.length === 0) {
         throw new Error('No results found');
     }
@@ -32,9 +37,14 @@ export const geocodeHere = (address, apiKey, appID) => __awaiter(void 0, void 0,
  * @param appID Application ID
  * @returns Reverse geocoded address
  */
-export const reverseGeocodeHere = (lat, lon, apiKey, appID) => __awaiter(void 0, void 0, void 0, function* () {
-    const url = `https://revgeocode.search.hereapi.com/v1/revgeocode?at=${lat}%2C${lon}&apiKey=${apiKey}&lang=en-US`;
-    const res = JSON.parse(yield httpsGet(url, appID));
+export const reverseGeocodeHere = (lat, lon, apiKey, appID, queryParameters) => __awaiter(void 0, void 0, void 0, function* () {
+    const url = new URL(`https://revgeocode.search.hereapi.com/v1/revgeocode?at=${lat}%2C${lon}&apiKey=${apiKey}`);
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            url.searchParams.append(key, queryParameters[key]);
+        }
+    }
+    const res = JSON.parse(yield httpsGet(url.toString(), appID));
     if (res.items.length === 0) {
         throw new Error('No results found');
     }

--- a/lib/module/utils/geocodeNominatim.d.ts
+++ b/lib/module/utils/geocodeNominatim.d.ts
@@ -4,7 +4,7 @@
  * @param appID Application ID
  * @returns Geocoded address
  */
-export declare const geocodeNominatim: (address: string, appID: string) => Promise<any>;
+export declare const geocodeNominatim: (address: string, appID: string, queryParameters?: Record<string, string>) => Promise<any>;
 /**
  * Reverse geocode address using Nominatim
  * @param lat Latitude
@@ -12,4 +12,4 @@ export declare const geocodeNominatim: (address: string, appID: string) => Promi
  * @param appID Application ID
  * @returns Reverse geocoded address
  */
-export declare const reverseGeocodeNominatim: (lat: number | string, lon: number | string, appID: string) => Promise<any>;
+export declare const reverseGeocodeNominatim: (lat: number | string, lon: number | string, appID: string, queryParameters?: Record<string, string>) => Promise<any>;

--- a/lib/module/utils/geocodeNominatim.js
+++ b/lib/module/utils/geocodeNominatim.js
@@ -14,11 +14,16 @@ import httpsGet from "./httpsGet.js";
  * @param appID Application ID
  * @returns Geocoded address
  */
-export const geocodeNominatim = (address, appID) => __awaiter(void 0, void 0, void 0, function* () {
+export const geocodeNominatim = (address, appID, queryParameters) => __awaiter(void 0, void 0, void 0, function* () {
     const encodedAddress = encodeURIComponent(address);
-    const apiUrl = `https://nominatim.openstreetmap.org/search?q=${encodedAddress}&format=json&addressdetails=1&limit=1`;
+    const apiUrl = new URL(`https://nominatim.openstreetmap.org/search?q=${encodedAddress}&format=json&addressdetails=1&limit=1`);
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            apiUrl.searchParams.append(key, queryParameters[key]);
+        }
+    }
     try {
-        const res = yield httpsGet(apiUrl, appID);
+        const res = yield httpsGet(apiUrl.toString(), appID);
         if (res.startsWith('<html>')) {
             throw new Error(res);
         }
@@ -48,12 +53,17 @@ export const geocodeNominatim = (address, appID) => __awaiter(void 0, void 0, vo
  * @param appID Application ID
  * @returns Reverse geocoded address
  */
-export const reverseGeocodeNominatim = (lat, lon, appID) => __awaiter(void 0, void 0, void 0, function* () {
+export const reverseGeocodeNominatim = (lat, lon, appID, queryParameters) => __awaiter(void 0, void 0, void 0, function* () {
     const encodedLat = encodeURIComponent(lat);
     const encodedLon = encodeURIComponent(lon);
-    const apiUrl = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${encodedLat}&lon=${encodedLon}`;
+    const apiUrl = new URL(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${encodedLat}&lon=${encodedLon}`);
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            apiUrl.searchParams.append(key, queryParameters[key]);
+        }
+    }
     try {
-        const res = yield httpsGet(apiUrl, appID);
+        const res = yield httpsGet(apiUrl.toString(), appID);
         if (res.startsWith('<html>')) {
             throw new Error(res);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,10 +99,10 @@ class NodeGeolocation {
      * @param address Address string to geocode
      * @returns Geocoding data
      */
-    public async getGeocoding(address: string): Promise<GeocodingData> {
+    public async getGeocoding(address: string, queryParameters?: Record<string, string>): Promise<GeocodingData> {
         if (!this.geocodingOptions) throw new Error('You must set geocodingOptions object before using this method');
         if (this.geocodingOptions.service === 'Nominatim') {
-            const data = await geocodeNominatim(address, this._id);
+            const data = await geocodeNominatim(address, this._id, queryParameters);
             return {
                 id: data.place_id,
                 address: {
@@ -126,7 +126,7 @@ class NodeGeolocation {
                 raw: data
             };
         } else if (this.geocodingOptions.service === 'Here') {
-            const data = await geocodeHere(address, this.geocodingOptions.key, this._id);
+            const data = await geocodeHere(address, this.geocodingOptions.key, this._id, queryParameters);
             return {
                 id: data.id,
                 address: {
@@ -160,7 +160,7 @@ class NodeGeolocation {
      * @param pos Position to reverse geocode
      * @returns Reverse geocoding data
      */
-    public async getReverseGeocoding(pos: Position): Promise<ReverseGeocodingData> {
+    public async getReverseGeocoding(pos: Position, queryParameters?: Record<string, string>): Promise<ReverseGeocodingData> {
         if (!this.geocodingOptions) throw new Error('You must set geocodingOptions object before using this method');
 
         let lat: number;
@@ -180,9 +180,9 @@ class NodeGeolocation {
         }
 
         if (this.geocodingOptions.service === 'Nominatim') {
-            return await reverseGeocodeNominatim(lat, lon, this._id);
+            return await reverseGeocodeNominatim(lat, lon, this._id, queryParameters);
         } else if (this.geocodingOptions.service === 'Here') {
-            return await reverseGeocodeHere(lat, lon, this.geocodingOptions.key, this._id);
+            return await reverseGeocodeHere(lat, lon, this.geocodingOptions.key, this._id, queryParameters);
         } else {
             throw new Error('Invalid service');
         }

--- a/src/utils/geocodeHere.ts
+++ b/src/utils/geocodeHere.ts
@@ -7,11 +7,17 @@ import httpsGet from "./httpsGet.js";
  * @param appID Application ID
  * @returns Geocoded address
  */
-export const geocodeHere = async (address: string, apiKey: string, appID: string): Promise<any> => {
+export const geocodeHere = async (address: string, apiKey: string, appID: string, queryParameters?: Record<string, string>): Promise<any> => {
     const encodedAddress = encodeURIComponent(address);
-    const url = `https://geocode.search.hereapi.com/v1/geocode?q=${encodedAddress}&apiKey=${apiKey}`;
+    const url = new URL(`https://geocode.search.hereapi.com/v1/geocode?q=${encodedAddress}&apiKey=${apiKey}`);
 
-    const res = JSON.parse(await httpsGet(url, appID));
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            url.searchParams.append(key, queryParameters[key]);
+        }
+    }
+
+    const res = JSON.parse(await httpsGet(url.toString(), appID));
 
     if (res.items.length === 0) {
         throw new Error('No results found');
@@ -28,10 +34,16 @@ export const geocodeHere = async (address: string, apiKey: string, appID: string
  * @param appID Application ID
  * @returns Reverse geocoded address
  */
-export const reverseGeocodeHere = async (lat: number, lon: number, apiKey: string, appID: string): Promise<any> => {
-    const url = `https://revgeocode.search.hereapi.com/v1/revgeocode?at=${lat}%2C${lon}&apiKey=${apiKey}&lang=en-US`;
+export const reverseGeocodeHere = async (lat: number, lon: number, apiKey: string, appID: string, queryParameters?: Record<string, string>): Promise<any> => {
+    const url = new URL(`https://revgeocode.search.hereapi.com/v1/revgeocode?at=${lat}%2C${lon}&apiKey=${apiKey}`);
 
-    const res = JSON.parse(await httpsGet(url, appID));
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            url.searchParams.append(key, queryParameters[key]);
+        }
+    }
+
+    const res = JSON.parse(await httpsGet(url.toString(), appID));
 
     if (res.items.length === 0) {
         throw new Error('No results found');

--- a/src/utils/geocodeNominatim.ts
+++ b/src/utils/geocodeNominatim.ts
@@ -6,12 +6,18 @@ import httpsGet from "./httpsGet.js";
  * @param appID Application ID
  * @returns Geocoded address 
  */
-export const geocodeNominatim = async (address: string, appID: string): Promise<any> => {
+export const geocodeNominatim = async (address: string, appID: string, queryParameters?: Record<string, string>): Promise<any> => {
     const encodedAddress = encodeURIComponent(address);
-    const apiUrl = `https://nominatim.openstreetmap.org/search?q=${encodedAddress}&format=json&addressdetails=1&limit=1`;
+    const apiUrl = new URL(`https://nominatim.openstreetmap.org/search?q=${encodedAddress}&format=json&addressdetails=1&limit=1`);
+
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            apiUrl.searchParams.append(key, queryParameters[key]);
+        }
+    }
 
     try {
-        const res = await httpsGet(apiUrl, appID);
+        const res = await httpsGet(apiUrl.toString(), appID);
 
         if (res.startsWith('<html>')) {
             throw new Error(res);
@@ -42,14 +48,20 @@ export const geocodeNominatim = async (address: string, appID: string): Promise<
  * @param appID Application ID
  * @returns Reverse geocoded address
  */
-export const reverseGeocodeNominatim = async (lat: number | string, lon: number | string, appID: string): Promise<any> => {
+export const reverseGeocodeNominatim = async (lat: number | string, lon: number | string, appID: string, queryParameters?: Record<string, string>): Promise<any> => {
     const encodedLat = encodeURIComponent(lat);
     const encodedLon = encodeURIComponent(lon);
 
-    const apiUrl = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${encodedLat}&lon=${encodedLon}`;
+    const apiUrl = new URL(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${encodedLat}&lon=${encodedLon}`);
+
+    if (queryParameters) {
+        for (const key in queryParameters) {
+            apiUrl.searchParams.append(key, queryParameters[key]);
+        }
+    }
 
     try {
-        const res = await httpsGet(apiUrl, appID);
+        const res = await httpsGet(apiUrl.toString(), appID);
 
         if (res.startsWith('<html>')) {
             throw new Error(res);


### PR DESCRIPTION
Closes #1.

This adds the possibility to add custom query params to geocoding and reverse geocoding options, for more advanced use cases.

Example of usage:
```ts
// Define geo with NodeGeolocation class
const data = await geo.getGeocoding('Rome, Italy', { lang: 'it' });

console.log(data.address.city); // "Roma"
console.log(data.address.country); // "Italia"
```